### PR TITLE
Reduce race condition window

### DIFF
--- a/apps/estatsd/src/estatsd_server.erl
+++ b/apps/estatsd/src/estatsd_server.erl
@@ -112,13 +112,13 @@ handle_cast({timing, Key, Duration}, State) ->
 handle_cast(flush, State) ->
   % Retrieve the metrics from the state and the env
   Counters = ets:tab2list(statsd),
-  Timers = gb_trees:to_list(State#state.timers),
+  ets:delete_all_objects(statsd),
 
   % Handle the flush in another process
+  Timers = gb_trees:to_list(State#state.timers),
   spawn(fun() -> flush_metrics_(Counters, Timers) end),
 
   % Continue with a blank slate
-  ets:delete_all_objects(statsd),
   NewState = State#state{timers = gb_trees:empty()},
   {noreply, NewState}.
 


### PR DESCRIPTION
If a large amount of data were in the ets table, more would be added while the gb_trees object is created. The only risk is that now a crash during flush_metrics would cause all the data to be lost, whereas before it might remain in the ets table (if this gen_server is not the owner because an owner crash deletes the ets table).
